### PR TITLE
Improve a bit ui and palette

### DIFF
--- a/qml/Main.qml
+++ b/qml/Main.qml
@@ -3,6 +3,7 @@ import QtQuick 2.0
 import "model"
 import "logic"
 import "pages"
+import "ui"
 
 App {
   // You get free licenseKeys from https://felgo.com/licenseKey
@@ -26,9 +27,17 @@ App {
     logic.fetchDraftTodos()
   }
 
+  onInitTheme: {
+    Theme.colors.tintColor = colorsManager.getBaseColor()
+  }
+
   // business logic
   Logic {
     id: logic
+  }
+
+  ColorsManager {
+    id: colorsManager
   }
 
   // model

--- a/qml/model/ConsoleLogger.qml
+++ b/qml/model/ConsoleLogger.qml
@@ -1,4 +1,5 @@
 import QtQuick 2.0
+import QtQml 2.3
 
 Item {
 

--- a/qml/pages/TodoDetailPage.qml
+++ b/qml/pages/TodoDetailPage.qml
@@ -1,5 +1,6 @@
 import Felgo 3.0
 import QtQuick 2.0
+import QtQml 2.3
 import "../ui"
 
 Page {

--- a/qml/pages/TodoListPage.qml
+++ b/qml/pages/TodoListPage.qml
@@ -90,23 +90,12 @@ Page {
     model: filteredModel
 
     // the delegate is the template item for each entry of the list
-    delegate: SimpleRow {
-      text: viewHelper.formatTodoId(model)
-      detailText: "Title: "+title
-      style.textColor: dataModel.isDraft(model) ? "grey" : Theme.listItem.textColor
 
-      // push detail page when selected, pass chosen todo id
-      onSelected: page.navigationStack.popAllExceptFirstAndPush(detailPageComponent, { todoId: model.id })
-
-      // show marker for completed todos
-      Rectangle {
-        anchors.left: parent.left
-        anchors.top: parent.top
-        anchors.bottom: parent.bottom
-        anchors.margins: dp(4)
-        width: dp(4)
-        color: completed ? "lightgreen" : Theme.secondaryBackgroundColor
-      }
+    delegate: TodoListEntry {
+        todoDraft: dataModel.isDraft(model)
+        todoTitle: title
+        todoComplete: completed
+        todoId: id
     }
 
     // item animations, supported by list view for view model types like JsonListModel, ListModel or SortFilterProxyModel

--- a/qml/ui/ColorsManager.qml
+++ b/qml/ui/ColorsManager.qml
@@ -1,0 +1,22 @@
+import QtQuick 2.0
+
+QtObject {
+  id: root
+
+  readonly property real _saturation: 0.2
+  readonly property real _value: 0.9
+  readonly property real _baseHue: 0.1
+
+  // How much difference we tolerate between similar hues.
+  readonly property real _spread: 0.1
+
+  function getBaseColor() {
+    return Qt.hsva(_baseHue, 1.0, 0.9, 1.0)
+  }
+
+  // Here we return a color which is similar to baseColor (their hue are very close)
+  function getPseudoRandomColor(id) {
+    var pseudoRandomHue = 1.0 + _baseHue + Math.sin(id * 1000) * _spread
+    return Qt.hsva(pseudoRandomHue % 1, _saturation, _value, 1.0)
+  }
+}

--- a/qml/ui/TodoListEntry.qml
+++ b/qml/ui/TodoListEntry.qml
@@ -6,21 +6,18 @@ import "../ui"
 Item {
   id: root
 
-  readonly property real saturation: 0.2
-  readonly property real value: 0.9
-
   property int todoId
   property bool todoDraft
   property string todoTitle
   property bool todoComplete
 
   // Each entry will have its pseudo random color (or grey if in draft)
-  property color color: todoDraft ? "lightgray" : getPseudoRandomColor(todoId)
+  property color color: todoDraft ? "lightgray" : colorsManager.getPseudoRandomColor(todoId)
   property color textColor: "#99000000"
   property color iconColor: Qt.darker(color, 1.5)
   property real margins: dp(8)
 
-  height: Math.max(title.contentHeight + 4 * margins, dp(64))
+  height: Math.max(title.contentHeight + 6 * margins, dp(64))
   width: parent.width
 
   AppPaper {
@@ -29,11 +26,12 @@ Item {
     background.color: color
     background.radius: margins
     elevated: true
+    shadowColor: "#44000000"
 
     // The todo text will be displayed as striked out and bold when completed
     AppText {
       id: title
-      anchors { left: parent.left; right: icon.left; top: parent.top; margins: root.margins }
+      anchors { left: parent.left; right: icon.left; top: parent.top; margins: root.margins * 2 }
       color: textColor
       text: todoTitle
       font.bold: completed
@@ -44,21 +42,16 @@ Item {
     Icon {
       id: icon
       anchors { right: parent.right; verticalCenter: parent.verticalCenter }
-      width: dp(64)
-      height: dp(64)
+      width: dp(48)
+      height: dp(48)
       color: iconColor
-      visible: todoComplete
-      icon: IconType.checkcircle
+      visible: todoComplete || todoDraft
+      icon: todoDraft ? IconType.pencil : IconType.checkcircle
     }
 
     MouseArea {
       anchors.fill: parent
       onClicked: page.navigationStack.popAllExceptFirstAndPush(detailPageComponent, { todoId: root.todoId })
     }
-  }
-
-  function getPseudoRandomColor(id) {
-    var pseudoRandomHue = Math.abs(Math.sin(id * 1000))
-    return Qt.hsva(pseudoRandomHue, saturation, value, 1.0)
   }
 }

--- a/qml/ui/TodoListEntry.qml
+++ b/qml/ui/TodoListEntry.qml
@@ -1,0 +1,64 @@
+import Felgo 3.0
+import QtQuick 2.0
+import QtQuick.Layouts 1.11
+import "../ui"
+
+Item {
+  id: root
+
+  readonly property real saturation: 0.2
+  readonly property real value: 0.9
+
+  property int todoId
+  property bool todoDraft
+  property string todoTitle
+  property bool todoComplete
+
+  // Each entry will have its pseudo random color (or grey if in draft)
+  property color color: todoDraft ? "lightgray" : getPseudoRandomColor(todoId)
+  property color textColor: "#99000000"
+  property color iconColor: Qt.darker(color, 1.5)
+  property real margins: dp(8)
+
+  height: Math.max(title.contentHeight + 4 * margins, dp(64))
+  width: parent.width
+
+  AppPaper {
+    anchors.fill: parent
+    anchors.margins: margins
+    background.color: color
+    background.radius: margins
+    elevated: true
+
+    // The todo text will be displayed as striked out and bold when completed
+    AppText {
+      id: title
+      anchors { left: parent.left; right: icon.left; top: parent.top; margins: root.margins }
+      color: textColor
+      text: todoTitle
+      font.bold: completed
+      font.strikeout: completed
+    }
+
+    // A checked icon will be displayed when the task is completed
+    Icon {
+      id: icon
+      anchors { right: parent.right; verticalCenter: parent.verticalCenter }
+      width: dp(64)
+      height: dp(64)
+      color: iconColor
+      visible: todoComplete
+      icon: IconType.checkcircle
+    }
+
+    MouseArea {
+      anchors.fill: parent
+      onClicked: page.navigationStack.popAllExceptFirstAndPush(detailPageComponent, { todoId: root.todoId })
+    }
+  }
+
+  function getPseudoRandomColor(id) {
+    var pseudoRandomHue = Math.abs(Math.sin(id * 1000))
+    return Qt.hsva(pseudoRandomHue, saturation, value, 1.0)
+  }
+}


### PR DESCRIPTION
With this pull requests there are small changes to layout and theming of this sample.

The main tint becomes orange and each todo entry has a different color (computed by its id) with a hue similar to orange.

The flat list is replaced also by card views with a checked or draft icon.